### PR TITLE
Extend production workarounds to userdebug as well

### DIFF
--- a/patches/build/soong/0002-Extend-production-workarounds-to-userdebug-as-well.patch
+++ b/patches/build/soong/0002-Extend-production-workarounds-to-userdebug-as-well.patch
@@ -1,0 +1,25 @@
+From 32c8a3aa11b9ff99bca39da80743fca3ed1e52be Mon Sep 17 00:00:00 2001
+From: Ximin Luo <infinity0@pwned.gg>
+Date: Sat, 13 Jun 2026 10:10:44 +0100
+Subject: [PATCH] Extend production workarounds to userdebug as well
+
+---
+ scripts/gen_build_prop.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/gen_build_prop.py b/scripts/gen_build_prop.py
+index 3dfeaf5..7904828 100644
+--- a/scripts/gen_build_prop.py
++++ b/scripts/gen_build_prop.py
+@@ -372,7 +372,7 @@ def append_additional_system_props(args):
+ 
+   props.append("ro.control_privapp_permissions=enforce")
+   props.append("net.tethering.noprovisioning=true")
+-  if config["BuildVariant"] == "user":
++  if config["BuildVariant"] == "user" or config["BuildVariant"] == "userdebug":
+     # at least one app (Revolut) refuses to work with yellow verifiedbootstate
+     props.append("ro.appcompat_override.ro.boot.verifiedbootstate=green")
+ 
+-- 
+2.53.0
+


### PR DESCRIPTION
This makes Revolut (and any other apps using this specific detection method) work on this userdebug build as well.